### PR TITLE
🔒 Fix SQL Injection vulnerability in RomulusService::purge_database

### DIFF
--- a/lib/romulus/service/romulus_service.cpp
+++ b/lib/romulus/service/romulus_service.cpp
@@ -305,18 +305,18 @@ auto RomulusService::purge_database() -> Result<void> {
   //   roms         →  games
   //   games        →  dat_versions
   //   dat_versions (no remaining children)
-  static constexpr std::array k_Tables = {
-      "rom_matches",
-      "files",
-      "global_roms",
-      "roms",
-      "games",
-      "dat_versions",
+  static constexpr std::array k_DeleteQueries = {
+      "DELETE FROM rom_matches",
+      "DELETE FROM files",
+      "DELETE FROM global_roms",
+      "DELETE FROM roms",
+      "DELETE FROM games",
+      "DELETE FROM dat_versions",
   };
 
   auto txn = db_->begin_transaction();
-  for (const auto* table : k_Tables) {
-    auto result = db_->execute(std::string("DELETE FROM ") + table);
+  for (const auto* query : k_DeleteQueries) {
+    auto result = db_->execute(query);
     if (!result) {
       return std::unexpected(result.error());
     }

--- a/tests/unit/test_classifier.cpp
+++ b/tests/unit/test_classifier.cpp
@@ -26,9 +26,8 @@ protected:
 
   /// Creates a DAT version and returns the dat_version_id.
   auto create_dat() -> std::int64_t {
-    romulus::core::DatVersion dat{.name = "Test",
-                                  .version = "1.0",
-                                  .source_url = {}, .checksum = "abc", .imported_at = {}};
+    romulus::core::DatVersion dat{
+        .name = "Test", .version = "1.0", .source_url = {}, .checksum = "abc", .imported_at = {}};
     auto dat_id = db_->insert_dat_version(dat);
     return *dat_id;
   }
@@ -71,7 +70,7 @@ TEST_F(ClassifierTest, ClassifiesVerifiedAndMissing) {
   romulus::core::FileInfo file{
       .path = "/roms/matched.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "11111111",
       .md5 = "11111111111111111111111111111111",
@@ -114,7 +113,7 @@ TEST_F(ClassifierTest, ClassifiesUnverifiedWithPartialMatch) {
   romulus::core::FileInfo file{
       .path = "/roms/partial.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aabb0011",
       .md5 = "cc000000cc000000cc000000cc000000",

--- a/tests/unit/test_classifier.cpp
+++ b/tests/unit/test_classifier.cpp
@@ -70,7 +70,8 @@ TEST_F(ClassifierTest, ClassifiesVerifiedAndMissing) {
   // File that matches rom1
   romulus::core::FileInfo file{
       .path = "/roms/matched.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "11111111",
       .md5 = "11111111111111111111111111111111",
@@ -112,7 +113,8 @@ TEST_F(ClassifierTest, ClassifiesUnverifiedWithPartialMatch) {
   // File with SAME CRC32 but DIFFERENT SHA1/MD5 — will be a CRC32-only match
   romulus::core::FileInfo file{
       .path = "/roms/partial.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aabb0011",
       .md5 = "cc000000cc000000cc000000cc000000",

--- a/tests/unit/test_database.cpp
+++ b/tests/unit/test_database.cpp
@@ -222,7 +222,8 @@ TEST_F(DatabaseTest, UpsertFileUpdatesExisting) {
   romulus::core::FileInfo file{
       .id = 0,
       .path = "/roms/test.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 1024,
       .crc32 = "aabbccdd",
       .md5 = "12345678901234567890123456789012",
@@ -313,7 +314,8 @@ TEST_F(DatabaseTest, FindsDuplicateFiles) {
   romulus::core::FileInfo file1{
       .id = 0,
       .path = "/roms/copy1.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aaaaaaaa",
       .md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -323,7 +325,8 @@ TEST_F(DatabaseTest, FindsDuplicateFiles) {
   romulus::core::FileInfo file2{
       .id = 0,
       .path = "/roms/copy2.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aaaaaaaa",
       .md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -347,7 +350,8 @@ TEST_F(DatabaseTest, FindsUnverifiedFiles) {
   romulus::core::FileInfo orphan{
       .id = 0,
       .path = "/roms/orphan.bin",
-      .entry_name = std::nullopt,
+      .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
       .size = 50,
       .crc32 = "bbbbbbbb",
       .md5 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -457,7 +461,8 @@ TEST_F(DatabaseTest, ComputedRomStatusVerifiedWhenExactMatchAndFileExists) {
 
   romulus::core::FileInfo file{.id = 0,
                                .path = "/roms/r.bin",
-                               .entry_name = std::nullopt,
+                               .archive_path = std::nullopt,
+        .entry_name = std::nullopt,
                                .size = 100,
                                .crc32 = {},
                                .md5 = {},

--- a/tests/unit/test_database.cpp
+++ b/tests/unit/test_database.cpp
@@ -166,7 +166,8 @@ TEST_F(DatabaseTest, DatVersionUniqueByChecksum) {
           auto r = db_->insert_dat_version(dat);
           (void)r;
         } catch (const std::runtime_error& ex) {
-          EXPECT_NE(std::string_view{ex.what()}.find("UNIQUE constraint failed"), std::string_view::npos);
+          EXPECT_NE(std::string_view{ex.what()}.find("UNIQUE constraint failed"),
+                    std::string_view::npos);
           throw;
         }
       },
@@ -223,7 +224,7 @@ TEST_F(DatabaseTest, UpsertFileUpdatesExisting) {
       .id = 0,
       .path = "/roms/test.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 1024,
       .crc32 = "aabbccdd",
       .md5 = "12345678901234567890123456789012",
@@ -315,7 +316,7 @@ TEST_F(DatabaseTest, FindsDuplicateFiles) {
       .id = 0,
       .path = "/roms/copy1.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aaaaaaaa",
       .md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -326,7 +327,7 @@ TEST_F(DatabaseTest, FindsDuplicateFiles) {
       .id = 0,
       .path = "/roms/copy2.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 100,
       .crc32 = "aaaaaaaa",
       .md5 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -351,7 +352,7 @@ TEST_F(DatabaseTest, FindsUnverifiedFiles) {
       .id = 0,
       .path = "/roms/orphan.bin",
       .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+      .entry_name = std::nullopt,
       .size = 50,
       .crc32 = "bbbbbbbb",
       .md5 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -462,7 +463,7 @@ TEST_F(DatabaseTest, ComputedRomStatusVerifiedWhenExactMatchAndFileExists) {
   romulus::core::FileInfo file{.id = 0,
                                .path = "/roms/r.bin",
                                .archive_path = std::nullopt,
-        .entry_name = std::nullopt,
+                               .entry_name = std::nullopt,
                                .size = 100,
                                .crc32 = {},
                                .md5 = {},

--- a/tests/unit/test_matcher.cpp
+++ b/tests/unit/test_matcher.cpp
@@ -79,6 +79,7 @@ protected:
     // File 1: exact match against ROM 1 via SHA1+MD5+CRC32
     romulus::core::FileInfo file{
         .path = "/roms/test.bin",
+        .archive_path = std::nullopt,
         .entry_name = std::nullopt,
         .size = 100,
         .crc32 = "aabb0011",
@@ -91,6 +92,7 @@ protected:
     // File 2: matches ROM 2 only via SHA256 — lower hashes differ
     romulus::core::FileInfo file_sha256_only{
         .path = "/roms/sha256_only.bin",
+        .archive_path = std::nullopt,
         .entry_name = std::nullopt,
         .size = 200,
         .crc32 = "ff110044",
@@ -105,6 +107,7 @@ protected:
     // File 3: no match at all
     romulus::core::FileInfo other{
         .path = "/roms/unknown.bin",
+        .archive_path = std::nullopt,
         .entry_name = std::nullopt,
         .size = 200,
         .crc32 = "00000000",


### PR DESCRIPTION
🎯 **What:** The `RomulusService::purge_database` method dynamically constructed SQL queries using string concatenation (`"DELETE FROM " + table`). This commit refactors the method to use an array of hardcoded `DELETE FROM <table>` query strings instead. Additionally, minor compilation errors in unit tests caused by missing designated initializers for `archive_path` were resolved.

⚠️ **Risk:** While the table names were hardcoded in an internal array (meaning no direct user input was present), dynamic query construction using string concatenation is a bad security practice and often flagged by SAST tools as a potential SQL injection vulnerability.

🛡️ **Solution:** The dynamic string concatenation has been entirely removed and replaced with safe, hardcoded string literals containing the full SQL commands. This ensures compliance with secure coding best practices without changing the execution logic or table deletion order.

---
*PR created automatically by Jules for task [18285902853923335154](https://jules.google.com/task/18285902853923335154) started by @lyquid*